### PR TITLE
feat(map): ISSUE-16 — Interactive map component with Leaflet + OpenStreetMap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "next-intl": "^4.8.3",
         "react": "19.2.3",
         "react-dom": "19.2.3",
-        "react-leaflet": "^5.0.0"
+        "react-leaflet": "^5.0.0",
+        "react-leaflet-cluster": "^4.0.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -6744,6 +6745,15 @@
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/leaflet.markercluster": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/leaflet.markercluster/-/leaflet.markercluster-1.5.3.tgz",
+      "integrity": "sha512-vPTw/Bndq7eQHjLBVlWpnGeLa3t+3zGiuM7fJwCkiMFq+nmRuG3RI3f7f4N4TDX7T4NpbAXpR2+NTRSEGfCSeA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "leaflet": "^1.3.1"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -7927,6 +7937,22 @@
         "leaflet": "^1.9.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
+      }
+    },
+    "node_modules/react-leaflet-cluster": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet-cluster/-/react-leaflet-cluster-4.0.0.tgz",
+      "integrity": "sha512-Lu75+KOu2ruGyAx8LoCQvlHuw+3CLLJQGEoSk01ymsDN/YnCiRV6ChkpsvaruVyYBPzUHwiskFw4Jo7WHj5qNw==",
+      "license": "SEE LICENSE IN <LICENSE>",
+      "dependencies": {
+        "leaflet.markercluster": "^1.5.3"
+      },
+      "peerDependencies": {
+        "@react-leaflet/core": "^3.0.0",
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "react-leaflet": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -9300,7 +9326,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "next-intl": "^4.8.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "react-leaflet": "^5.0.0"
+    "react-leaflet": "^5.0.0",
+    "react-leaflet-cluster": "^4.0.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/src/components/map/EventMap.tsx
+++ b/src/components/map/EventMap.tsx
@@ -1,0 +1,209 @@
+'use client';
+
+import 'leaflet/dist/leaflet.css';
+import 'react-leaflet-cluster/dist/assets/MarkerCluster.css';
+import 'react-leaflet-cluster/dist/assets/MarkerCluster.Default.css';
+
+
+import L, { type LatLngBounds } from 'leaflet';
+import {
+    MapContainer,
+    TileLayer,
+    Marker,
+    Popup,
+    useMapEvents,
+    useMap,
+} from 'react-leaflet';
+import MarkerClusterGroup from 'react-leaflet-cluster';
+import { useEffect, useRef } from 'react';
+
+// ── Leaflet icon Webpack fix ─────────────────────────────────────────────────
+// Next.js/Webpack can't resolve Leaflet's default icon URLs; override manually.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+delete (L.Icon.Default.prototype as any)._getIconUrl;
+L.Icon.Default.mergeOptions({
+    iconRetinaUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon-2x.png',
+    iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
+    shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
+});
+
+// ── Terrain token colours (mirrors globals.css) ──────────────────────────────
+const TERRAIN_COLORS: Record<Terrain, string> = {
+    road: '#3B82F6',
+    trail: '#22C55E',
+    ultra: '#F97316',
+    cross: '#A855F7',
+};
+
+/** Creates a 14×14 SVG circle DivIcon for a terrain type. */
+function makeTerrainIcon(terrain: Terrain): L.DivIcon {
+    const color = TERRAIN_COLORS[terrain];
+    return L.divIcon({
+        className: '',
+        html: `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18">
+            <circle cx="9" cy="9" r="7" fill="${color}" stroke="#0a0a0f" stroke-width="2"/>
+        </svg>`,
+        iconSize: [18, 18],
+        iconAnchor: [9, 9],
+        popupAnchor: [0, -12],
+    });
+}
+
+// ── Types ────────────────────────────────────────────────────────────────────
+type Terrain = 'road' | 'trail' | 'ultra' | 'cross';
+
+export interface MapEvent {
+    id: string;
+    lat: number;
+    lng: number;
+    terrain: Terrain;
+    title: string;
+}
+
+export interface EventMapProps {
+    events: MapEvent[];
+    /** ID of the currently selected event (highlights marker). */
+    selectedId?: string | null;
+    /** Called when a marker is clicked with the event's ID. */
+    onMarkerClick: (id: string) => void;
+    /** Called on every map moveend with the new visible bounds. */
+    onBoundsChange: (bounds: LatLngBounds) => void;
+}
+
+// ── Child: fit map to all event markers on first render ──────────────────────
+function InitialBounds({ events }: { events: MapEvent[] }) {
+    const map = useMap();
+    const fitted = useRef(false);
+
+    useEffect(() => {
+        if (fitted.current || events.length === 0) return;
+        const bounds = L.latLngBounds(events.map(e => [e.lat, e.lng]));
+        map.fitBounds(bounds, { padding: [40, 40] });
+        fitted.current = true;
+    }, [map, events]);
+
+    return null;
+}
+
+// ── Child: emit bounds on moveend ────────────────────────────────────────────
+function BoundsWatcher({ onBoundsChange }: { onBoundsChange: (b: LatLngBounds) => void }) {
+    useMapEvents({
+        moveend: (e) => {
+            onBoundsChange(e.target.getBounds() as LatLngBounds);
+        },
+    });
+    return null;
+}
+
+// ── Child: geolocate button ──────────────────────────────────────────────────
+function GeolocateControl() {
+    const map = useMap();
+
+    function locate() {
+        if (!navigator.geolocation) return;
+        navigator.geolocation.getCurrentPosition(
+            ({ coords }) => {
+                map.setView([coords.latitude, coords.longitude], 13, { animate: true });
+            },
+            () => { /* silently fail */ }
+        );
+    }
+
+    return (
+        <button
+            onClick={locate}
+            title="Go to my location"
+            aria-label="Go to my location"
+            style={{
+                position: 'absolute',
+                bottom: '2.5rem',
+                right: '0.75rem',
+                zIndex: 1000,
+                background: '#0f172a',
+                border: '1px solid rgba(255,255,255,0.08)',
+                borderRadius: '8px',
+                width: '36px',
+                height: '36px',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                cursor: 'pointer',
+                color: '#ededed',
+            }}
+        >
+            {/* crosshair SVG */}
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="12" cy="12" r="3" />
+                <line x1="12" y1="2" x2="12" y2="6" />
+                <line x1="12" y1="18" x2="12" y2="22" />
+                <line x1="2" y1="12" x2="6" y2="12" />
+                <line x1="18" y1="12" x2="22" y2="12" />
+            </svg>
+        </button>
+    );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+/**
+ * Full-viewport interactive Leaflet map with:
+ * - CartoDB Dark Matter tiles
+ * - Terrain-colored custom markers
+ * - Marker clustering via react-leaflet-cluster
+ * - fitBounds on initial load
+ * - Geolocate button
+ * - Viewport bounds emitted on moveend
+ *
+ * Must be consumed via the dynamic-import wrapper in map/index.ts (ssr: false).
+ */
+export function EventMap({ events, selectedId, onMarkerClick, onBoundsChange }: EventMapProps) {
+    const iconCache = useRef<Partial<Record<Terrain, L.DivIcon>>>({});
+
+    function getIcon(terrain: Terrain): L.DivIcon {
+        if (!iconCache.current[terrain]) {
+            iconCache.current[terrain] = makeTerrainIcon(terrain);
+        }
+        return iconCache.current[terrain]!;
+    }
+
+    return (
+        <MapContainer
+            center={[40.4168, -3.7038]} /* Madrid default */
+            zoom={6}
+            scrollWheelZoom
+            style={{ height: '100%', width: '100%' }}
+        >
+            {/* CartoDB Dark Matter */}
+            <TileLayer
+                attribution='&copy; <a href="https://carto.com/attributions">CARTO</a> &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+                url="https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png"
+                subdomains="abcd"
+                maxZoom={19}
+            />
+
+            {/* Clustered markers */}
+            <MarkerClusterGroup chunkedLoading>
+                {events.map((event) => (
+                    <Marker
+                        key={event.id}
+                        position={[event.lat, event.lng]}
+                        icon={getIcon(event.terrain)}
+                        eventHandlers={{
+                            click: () => onMarkerClick(event.id),
+                        }}
+                        opacity={selectedId && selectedId !== event.id ? 0.45 : 1}
+                    >
+                        <Popup>
+                            <span style={{ fontSize: '0.8rem', fontWeight: 600 }}>
+                                {event.title}
+                            </span>
+                        </Popup>
+                    </Marker>
+                ))}
+            </MarkerClusterGroup>
+
+            <InitialBounds events={events} />
+            <BoundsWatcher onBoundsChange={onBoundsChange} />
+            <GeolocateControl />
+        </MapContainer>
+    );
+}

--- a/src/components/map/index.ts
+++ b/src/components/map/index.ts
@@ -1,0 +1,13 @@
+import dynamic from 'next/dynamic';
+import type { EventMapProps } from './EventMap';
+
+/**
+ * SSR-safe re-export of EventMap.
+ * Leaflet accesses `window` on import, so the component must be loaded
+ * client-side only (ssr: false).
+ * The parent container is responsible for showing a skeleton while loading.
+ */
+export const EventMap = dynamic<EventMapProps>(
+    () => import('./EventMap').then((m) => m.EventMap),
+    { ssr: false }
+);


### PR DESCRIPTION
Implements ISSUE-16: Interactive Leaflet map component — the centrepiece of the application.

## What is included

**src/components/map/EventMap.tsx** ('use client')
- CartoDB Dark Matter tile layer
- Custom SVG DivIcon markers per terrain type (road=blue, trail=green, ultra=orange, cross=purple)
- Marker clustering via react-leaflet-cluster@4.0.0
- itBounds on initial load using all event coordinates
- Geolocate button (HTML5 Geolocation API)
- moveend viewport bounds callback prop
- Leaflet Webpack icon fix applied

**src/components/map/index.ts**
- 
ext/dynamic wrapper with ssr: false (Leaflet accesses window on import)

**New dependency:** eact-leaflet-cluster@4.0.0 (compatible with react-leaflet v5 + React 19)

## Verification

- 
px tsc --noEmit — no errors
- 
ext build — exit 0

Closes #15